### PR TITLE
PIZ3: Fix order price calculation

### DIFF
--- a/app/controllers/order.py
+++ b/app/controllers/order.py
@@ -12,7 +12,7 @@ class OrderController(BaseController):
 
     @staticmethod
     def calculate_order_price(size_price: float, ingredients: list):
-        price = sum(ingredient.price for ingredient in ingredients)
+        price = size_price + sum(ingredient.price for ingredient in ingredients)
         return round(price, 2)
 
     @classmethod


### PR DESCRIPTION
#### :thinking: Why?

-  Fix order price calculation

#### :twisted_rightwards_arrows: What I changed:

- app/controllers/order.py

#### :spiral_notepad: Trello Card:

- https://trello.com/c/Az0PUPZt

#### :dart: Functional Results:

- ![image](https://github.com/dalf2598/python-pizza-planet/assets/45211514/2d439ef0-0ce7-4655-ad7d-00a7a8921122)
- ![image](https://github.com/dalf2598/python-pizza-planet/assets/45211514/c6e506c0-a34b-4dac-b17a-bd01d0041e34)
- ![image](https://github.com/dalf2598/python-pizza-planet/assets/45211514/1b75b7ff-6257-416c-ab4b-0534f46951dc)


